### PR TITLE
Data field different format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,8 +32,10 @@ function fluentAppender(config, layout) {
   const logSender = FluentSender.createFluentSender(tag_prefix, options);
 
   const appender = function(loggingEvent) {
-    const data =  util.format.apply(null, loggingEvent.data);
-    const rec = {
+    const data =  loggingEvent.data[0];
+    const extra = loggingEvent.data.splice(1);
+
+    let rec = {
       timestamp: loggingEvent.startTime.getTime(),
       category: loggingEvent.categoryName,
       levelInt: loggingEvent.level.level,
@@ -41,6 +43,11 @@ function fluentAppender(config, layout) {
       context: loggingEvent.context,
       data: data
     };
+
+    if (extra.length) {
+      rec['extra'] = Object.assign(...extra);
+    }
+
     if (options.levelTag !== false) {
       logSender.emit(loggingEvent.level.levelStr, rec);
     } else {

--- a/test/test.log4js.js
+++ b/test/test.log4js.js
@@ -118,4 +118,37 @@ describe('log4js-fluent-appender', () => {
     done();
   });
 
+  it('should log extra', (done) => {
+    const tag_prefix = 'tag_prefix';
+    const options = {
+      levelTag: false,
+      host: 'localhost',
+      port: 24224
+    };
+    const fakeSender = {
+      emit: td.function()
+    };
+    td
+      .when(fluentLogger.createFluentSender(tag_prefix, options))
+      .thenReturn(fakeSender);
+    const logger = getLogger(tag_prefix, options);
+
+    logger.info('This is info message!', {extra1: true, extra2: false}, {extra3: true});
+
+    td.verify(fakeSender.emit({
+      timestamp: td.matchers.anything(),
+      category: 'default',
+      levelInt: 20000,
+      levelStr: 'INFO',
+      context: {},
+      data: 'This is info message!',
+      extra: {
+        extra1: true,
+        extra2: false,
+        extra3: true,
+      }
+    }));
+    done();
+  });
+
 });


### PR DESCRIPTION
I've made some change in order to parse "data" field differently.
Right now .info, .warning etc methods accepts multiple arguments and they are collapsed into one string finally.
In this version:
* first argument from .info is passed to data
* all others are passed to additional field "extra" and merged together via Object.assign